### PR TITLE
Fix of big Regexp issue

### DIFF
--- a/lib/css-url-rewriter.js
+++ b/lib/css-url-rewriter.js
@@ -12,7 +12,7 @@ var extend = require('extend');
 // Regex to find CSS properties that contain URLs
 // Fiddle: http://refiddle.com/refiddles/css-url-matcher
 // Railroad: http://goo.gl/LXpk52
-var cssPropertyMatcher = /@import[^;]*|[;\s]?\*?[a-zA-Z\-]+\s*\:\#?[\s\S]*url\(\s*['"]?[^'"\)\s]+['"]?\s*\)[^;}]*/g;
+var cssPropertyMatcher = /@import[^;]*|[;\s]?\*?[a-zA-Z\-]+\s*\:\#?[^;}]*url\(\s*['"]?[^'"\)\s]+['"]?\s*\)[^;}]*/g;
 
 // Regex to find the URLs within a CSS property value
 // Fiddle: http://refiddle.com/refiddles/match-multiple-urls-within-a-css-property-value
@@ -32,7 +32,7 @@ module.exports = function rewriteCSSURLs(css, settings, rewriterFn) {
   settings = extend({}, defaults, settings);
 
   // Return the modified CSS
-  var result = css.toString().replace(cssPropertyMatcher, function(property, urlValue) {
+  var result = css.toString().replace(cssPropertyMatcher, function(property) {
     // This function deals with an individual CSS property.
 
     // If this property is excluded, return it unchanged

--- a/test/expected/msie-behavior.css
+++ b/test/expected/msie-behavior.css
@@ -1,13 +1,18 @@
-/* URLs in IE's 'behavior' property are skipped, by default */
+/* URLs in IE's 'behavior' property are skipped, by default
+ * We'll test skipping of 'behavior' and processing 'notbehavior'
+ */
 *, *:before, *:after {
   box-sizing: border-box;
-  
+
   /* without hack */
-  behavior: url(_scripts/boxsizing.htc);
-  behavior  : url(  _scripts/boxsizing.htc  );
-  
+  behavior: url(scripts/boxsizing.htc);
+  behavior  : url(  scripts/boxsizing.htc  );
+  notbehavior: url(_scripts/boxsizing.htc);
+  notbehavior  : url(  _scripts/boxsizing.htc  );
+
   /* with IE<8 hack */
-  *behavior: url(_scripts/boxsizing.htc);
+  *behavior: url(scripts/boxsizing.htc);
+  *notbehavior: url(_scripts/boxsizing.htc);
 }
 
 .thing {

--- a/test/fixtures/msie-behavior.css
+++ b/test/fixtures/msie-behavior.css
@@ -1,13 +1,18 @@
-/* URLs in IE's 'behavior' property are skipped, by default */
+/* URLs in IE's 'behavior' property are skipped, by default
+ * We'll test skipping of 'behavior' and processing 'notbehavior'
+ */
 *, *:before, *:after {
   box-sizing: border-box;
-  
+
   /* without hack */
   behavior: url(scripts/boxsizing.htc);
   behavior  : url(  scripts/boxsizing.htc  );
-  
+  notbehavior: url(scripts/boxsizing.htc);
+  notbehavior  : url(  scripts/boxsizing.htc  );
+
   /* with IE<8 hack */
   *behavior: url(scripts/boxsizing.htc);
+  *notbehavior: url(scripts/boxsizing.htc);
 }
 
 .thing {


### PR DESCRIPTION
Previously `cssPropertyMatcher` did desperately wrong job. It matched too much, too slow.
Test this css for example https://raw.githubusercontent.com/twbs/bootstrap/v3.2.0/dist/css/bootstrap.css

Because of this excludeProperties didn't work in some cases. And unitests was fixed up to this issue.

I've fixed regexp and related thing.
