### PR TITLE
Fixing the Regex to deal with a corner case for background:url

### DIFF
--- a/lib/css-url-rewriter.js
+++ b/lib/css-url-rewriter.js
@@ -12,7 +12,7 @@ var extend = require('extend');
 // Regex to find CSS properties that contain URLs
 // Fiddle: http://refiddle.com/refiddles/css-url-matcher
 // Railroad: http://goo.gl/LXpk52
-var cssPropertyMatcher = /@import[^;]*|[;\s]?\*?[a-zA-Z\-]+\s*\:\#?[\s\S]*url\(\s*['"]?[^'"\)\s]+['"]?\s*\)[^;}]*/g;
+var cssPropertyMatcher = /@import[^;]*|[;\s{]?\*?[a-zA-Z\-]+\s*\:\#?[\s\S]*url\(\s*['"]?[^'"\)\s]+['"]?\s*\)[^;}]*/g;
 
 // Regex to find the URLs within a CSS property value
 // Fiddle: http://refiddle.com/refiddles/match-multiple-urls-within-a-css-property-value

--- a/lib/css-url-rewriter.js
+++ b/lib/css-url-rewriter.js
@@ -12,7 +12,7 @@ var extend = require('extend');
 // Regex to find CSS properties that contain URLs
 // Fiddle: http://refiddle.com/refiddles/css-url-matcher
 // Railroad: http://goo.gl/LXpk52
-var cssPropertyMatcher = /@import[^;]*|[;\s{]?\*?[a-zA-Z\-]+\s*\:\#?[\s\S]*url\(\s*['"]?[^'"\)\s]+['"]?\s*\)[^;}]*/g;
+var cssPropertyMatcher = /@import[^;]*|[;\s{]?\*?[a-zA-Z\-]+\s*\:\#?[\s\S]*url\(\s*['"]?[^'"\)\s]+[\w-]*['"]?\s*\)[^;}]*/g;
 
 // Regex to find the URLs within a CSS property value
 // Fiddle: http://refiddle.com/refiddles/match-multiple-urls-within-a-css-property-value


### PR DESCRIPTION
If you had a case like this
```css
background:url(...) no-repeat
```
The regex would fail because it assumed that `background:url(...)` was the last expression in the CSS block